### PR TITLE
chore(docs) Lerna is not a global dip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,7 @@ First Time? Get up a running:
 ```
 git clone git@github.com:quillio/stringy.git
 cd ./stringy
-npm i -g lerna
-lerna boostrap
+npm install
 ```
 
 ## Working on a module
@@ -21,7 +20,7 @@ that:
 
 When working on one of the modules make it your current directory.
 From the modules directory we can run commands specifically for that module like:
-1. Adding new npm dependencies with `yarn add <new-package>`
+1. Adding new npm dependencies with `npm install <new-package> --save`
  
 ### Commands
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Common string utilties written in JavaScript",
   "main": "index.js",
   "scripts": {
+    "bootstrap": "lerna bootstrap",
     "build": "babel ./src --ignore src/**/*.spec.js -d ./dist",
     "test": "ava",
     "docs": "cd ./docs && npm run develop",
-    "deploy:docs": "cd ./docs && npm run deploy"
+    "deploy:docs": "cd ./docs && npm run deploy",
+    "postinstall": "npm run bootstrap"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The contributing guide is telling the user to install lerna globally; however, it is a dev dependency already. The contributing guide is updated with this part removed, as well as NPM script tasks to automatically run `lerna bootstrap` post install or via `npm run bootstrap`.

Closes #3